### PR TITLE
fix: passing global theme vars to themer's resolveAttributes function

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "precommit": "npm run lint && npm run test"
   },
   "dependencies": {
-    "ca-ui-themer": "^1.0.0",
+    "ca-ui-themer": "^1.1.1",
     "lodash": "^4.17.2"
   },
   "peerDependencies": {

--- a/src/react-themer/index.js
+++ b/src/react-themer/index.js
@@ -10,6 +10,10 @@ import React, { Component, PropTypes } from 'react';
 import { getDisplayName } from '../utils';
 
 export default (customThemer: ?Object) => (theme?: Object) => (component: React.Element<*>) => {
+  if (!component) {
+    throw new Error('ca-ui-react-themer: a component is required');
+  }
+
   let rawThemerAttrs: Object;
   if (
     component.rawThemerAttrs &&
@@ -33,7 +37,7 @@ export default (customThemer: ?Object) => (theme?: Object) => (component: React.
   let resolvedAttrs;
 
   return class extends Component {
-    static displayName = `Themer(${getDisplayName(rawThemerAttrs.component) || 'Component'})`;
+    static displayName = `Themer(${getDisplayName(rawThemerAttrs.component)})`;
     static rawThemerAttrs = rawThemerAttrs;
 
     static contextTypes = {

--- a/src/react-themer/index.js
+++ b/src/react-themer/index.js
@@ -31,7 +31,6 @@ export default (customThemer: ?Object) => (theme?: Object) => (component: React.
   const themerInstance = customThemer || themer;
 
   let resolvedAttrs;
-  let themesToResolve;
 
   return class extends Component {
     static displayName = `Themer(${getDisplayName(rawThemerAttrs.component) || 'Component'})`;
@@ -42,19 +41,17 @@ export default (customThemer: ?Object) => (theme?: Object) => (component: React.
     };
 
     componentWillMount() {
-      const { theme: globalTheme } = this.context;
-
-      if (!resolvedAttrs) {
-        // Merge global theme vars with the current theme if necessary
-        if (globalTheme && globalTheme.variables) {
-          themesToResolve = [{ variables: globalTheme.variables }, ...rawThemerAttrs.themes];
-        } else {
-          themesToResolve = rawThemerAttrs.themes;
-        }
-
-        // Fetch the resolved Component and theme from the themerInstance
-        resolvedAttrs = themerInstance.resolveAttributes(rawThemerAttrs.component, themesToResolve);
+      if (resolvedAttrs) {
+        return;
       }
+
+      // Check if global theme defines any variables
+      const { theme: globalTheme } = this.context;
+      const globalVars = globalTheme && globalTheme.variables ? globalTheme.variables : null;
+
+      // Fetch the resolved Component and theme from the themerInstance
+      resolvedAttrs = themerInstance.resolveAttributes(
+        rawThemerAttrs.component, rawThemerAttrs.themes, globalVars);
     }
 
     render() {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -14,13 +14,13 @@
  * @return {string}        The name of the component as a string
  * @public
  */
-export function getDisplayName(Component?: string | Object): ?string {
+export function getDisplayName(Component?: string | Object): string {
   if (typeof Component === 'string') {
     return Component;
   }
 
   if (!Component) {
-    return undefined;
+    return '';
   }
 
   return Component.displayName || Component.name || 'Component';

--- a/tests/fixtures/functionTheme.js
+++ b/tests/fixtures/functionTheme.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2017 CA. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+export default {
+  variables: (_, globalVars) => ({
+    color: globalVars.mainColor || 'blue',
+  }),
+  styles: (_, vars) => ({
+    header: {
+      color: vars.color,
+    },
+  }),
+};

--- a/tests/fixtures/globalTheme.js
+++ b/tests/fixtures/globalTheme.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2017 CA. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+export default {
+  variables: {
+    mainColor: 'purple',
+  },
+};

--- a/tests/theme-provider/index.spec.js
+++ b/tests/theme-provider/index.spec.js
@@ -7,7 +7,7 @@
 /* eslint-disable no-console */
 
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import ThemeProvider from '../../src/theme-provider';
 import TestComponent from '../fixtures/TestComponent';
 import theme from '../fixtures/theme';
@@ -39,14 +39,14 @@ describe('ThemeProvider', () => {
 
   it('should contain child prop', () => {
     const ProviderComponent = <ThemeProvider {...props}><TestComponent /></ThemeProvider>;
-    const renderedComponent = shallow(ProviderComponent);
+    const renderedComponent = mount(ProviderComponent);
 
     expect(renderedComponent.prop('children')).toBeTruthy();
   });
 
   it('should not contain child prop', () => {
     const ProviderComponent = <ThemeProvider {...props} />;
-    const renderedComponent = shallow(ProviderComponent);
+    const renderedComponent = mount(ProviderComponent);
 
     expect(renderedComponent.prop('children')).toBeUndefined();
   });

--- a/tests/utils/index.spec.js
+++ b/tests/utils/index.spec.js
@@ -9,8 +9,8 @@ import TestComponent from '../fixtures/TestComponent';
 
 // use dirty chai to avoid unused expressions
 describe('getDisplayName', () => {
-  it('should return undefined if no argument is provided', () => {
-    expect(getDisplayName()).toBeUndefined();
+  it('should return empty string if falsy argument is provided', () => {
+    expect(getDisplayName(null)).toBe('');
   });
 
   it('should return the unchanged argument if a string is passed', () => {


### PR DESCRIPTION
## Status
**READY**

## Description
Passing global theme variables to `themer` to be used when resolving component theme. Previously, global variables were passed in the theme array as a regular parent theme, now they are passed in a way so that `themer` can distinguish them from component theme variables.

After this fix, the component developer will be able to use global variables as expected inside of component themes:

```js
<ThemeProvider theme={{ variables: { mainColor: 'blue' } }}>
  <MyComponent />
<ThemeProvider>
```

```js
const myComponentTheme = {
  variables: (_, globalVars) => ({
    color: globalVars.mainColor,  // => 'blue'
    ...
  }),
  ...
};
```