### PR TITLE
fix: use `undefined` instead of `null` for missing global variables

### DIFF
--- a/src/react-themer/index.js
+++ b/src/react-themer/index.js
@@ -58,7 +58,7 @@ export default (customThemer: ?Object) => (theme?: Object) => (component: React.
 
       // Check if global theme defines any variables
       const { theme: globalTheme } = this.context;
-      const globalVars = globalTheme && globalTheme.variables ? globalTheme.variables : null;
+      const globalVars = globalTheme && globalTheme.variables ? globalTheme.variables : undefined;
 
       // apply variants decorator
       const componentWithVariants = applyVariantsDecorator(rawThemerAttrs.component);

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -75,6 +75,25 @@ describe('reactThemer', () => {
     expect(renderedThemeProp.styles.root.color).toBe(globalTheme.variables.mainColor);
   });
 
+  it('should set global vars to undefined if no global theme is defined', () => {
+    const defaultGlobalVars = { mainColor: 'purple' };
+    const testFunctionTheme = {
+      variables: (_, globalVars = defaultGlobalVars) => ({
+        color: globalVars.mainColor || 'blue',
+      }),
+      styles: (_, vars) => ({
+        root: {
+          color: vars.color,
+        },
+      }),
+    };
+    const themerReactClass = reactThemer(testFunctionTheme)(TestComponent);
+    const renderedComponent = mount(React.createElement(themerReactClass));
+
+    const renderedThemeProp = renderedComponent.find(TestComponent).prop('theme');
+    expect(renderedThemeProp.styles.root.color).toBe(defaultGlobalVars.mainColor);
+  });
+
   it('should call resolveAttributes only once', () => {
     const themer = createThemer();
 


### PR DESCRIPTION
## Status
**READY**

## Description
This fix allows theme developers to define their theme variables functions with default values for the `globalVariables` argument. Example:
```js
const theme = { 
  variables: (vars, globalVars = {}) => {
    ...
  },
}
```

## Impacted Areas in Application

* decorator
