### PR TITLE
feat: add flow type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,35 +29,36 @@
     "precommit": "npm run lint && npm run flow && npm run test"
   },
   "dependencies": {
-    "ca-ui-themer": "^2.1.1",
-    "lodash": "^4.17.2",
-    "recompose": "^0.22.0"
+    "ca-ui-themer": "^2.3.0",
+    "lodash": "^4.17.4",
+    "react-flow-types": "^0.1.1",
+    "recompose": ">=0.5.0"
   },
   "peerDependencies": {
     "react": ">=0.14"
   },
   "devDependencies": {
-    "babel-cli": "^6.18.0",
-    "babel-eslint": "^7.1.1",
+    "babel-cli": "^6.24.1",
+    "babel-eslint": "^7.2.2",
     "babel-preset-ca": "^1.1.0",
-    "babel-register": "^6.18.0",
+    "babel-register": "^6.24.1",
     "codecov": "2.1.0",
     "commitizen": "2.9.6",
     "cz-conventional-changelog": "2.0.0",
-    "enzyme": "^2.7.1",
-    "eslint": "^3.11.1",
-    "eslint-config-ca": "^2.0.0",
+    "enzyme": "^2.8.1",
+    "eslint": "^3.19.0",
+    "eslint-config-ca": "^2.0.1",
     "flow-bin": "^0.43.1",
     "flow-copy-source": "^1.1.0",
     "flow-coverage-report": "^0.3.0",
     "husky": "^0.13.3",
     "jest": "^19.0.2",
-    "react": "^15.4.1",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.4.1",
-    "rimraf": "^2.5.4",
+    "react": "15.4.1",
+    "react-addons-test-utils": "15.4.1",
+    "react-dom": "15.4.1",
+    "rimraf": "^2.6.1",
     "semantic-release": "^6.3.2",
-    "validate-commit-msg": "^2.8.2"
+    "validate-commit-msg": "^2.12.1"
   },
   "config": {
     "validate-commit-msg": {

--- a/src/react-themer/index.js
+++ b/src/react-themer/index.js
@@ -3,6 +3,7 @@
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
+
 // @flow
 
 import {
@@ -12,75 +13,161 @@ import {
 } from 'ca-ui-themer';
 import React, { Component, PropTypes } from 'react';
 import mapProps from 'recompose/mapProps';
+
+import type { ProvidedThemeProps } from 'ca-ui-themer';
+import type { HigherOrderComponent } from 'react-flow-types';
+
 import { getDisplayName } from '../utils';
 
+/**
+ * Define Higher Order Component type
+ * @type {WithThemeDecorator}
+ */
+type WithThemeDecorator = HigherOrderComponent<{}, ProvidedThemeProps>;
+
+/**
+ * Create variants prop mapper with `recompsoe/mapProps`
+ * @type {HigherOrderComponent}
+ */
 const applyVariantsDecorator = mapProps(applyVariantsProps);
 
-export default (customThemer: ?Object) => {
-  const themerInstance = customThemer || themer;
-
-  const reactThemerJss = (theme?: Object) => (
-    component: Component<any, any, any> | Function,
-  ) => {
-    if (!component) {
-      throw new Error('ca-ui-react-themer: a component is required');
-    }
-
-    let rawThemerAttrs: Object;
-    if (
-      component.rawThemerAttrs &&
-      component.rawThemerAttrs.component &&
-      component.rawThemerAttrs.themes &&
-      Array.isArray(component.rawThemerAttrs.themes)
-    ) {
-      rawThemerAttrs = {
-        component: component.rawThemerAttrs.component,
-        themes: [...component.rawThemerAttrs.themes, theme],
-      };
-    } else {
-      rawThemerAttrs = {
-        component,
-        themes: [theme],
-      };
-    }
-
-    let resolvedAttrs;
-
-    return class extends Component {
-      static displayName = `Themer(${getDisplayName(rawThemerAttrs.component)})`;
-      static rawThemerAttrs = rawThemerAttrs;
-
-      static contextTypes = {
-        theme: PropTypes.object,
-      };
-
-      componentWillMount() {
-        if (resolvedAttrs) {
-          return;
-        }
-
-        // Check if global theme defines any variables
-        const { theme: globalTheme } = this.context;
-        const globalVars = globalTheme && globalTheme.variables ? globalTheme.variables : undefined;
-
-        // apply variants decorator
-        const componentWithVariants = applyVariantsDecorator(rawThemerAttrs.component);
-
-        // Fetch the resolved Component and theme from the themerInstance
-        resolvedAttrs = themerInstance.resolveAttributes(
-          componentWithVariants, rawThemerAttrs.themes, globalVars);
-      }
-
-      render() {
-        return React.createElement(
-          resolvedAttrs.snippet,
-          mapThemeProps(this.props, resolvedAttrs.theme),
-        );
-      }
+/**
+ * Build themer attributes based on input component and current theme.
+ *
+ * @param  {any} component  Input component
+ * @param  {Object} theme   Current theme
+ * @return {Object}         New object with `component` and `themes` array
+ */
+const getRawThemerAttrs = (component: any, theme?: Object) => {
+  if (
+    component &&
+    component.rawThemerAttrs &&
+    component.rawThemerAttrs.component &&
+    component.rawThemerAttrs.themes &&
+    Array.isArray(component.rawThemerAttrs.themes)
+  ) {
+    return {
+      component: component.rawThemerAttrs.component,
+      themes: [...component.rawThemerAttrs.themes, theme],
     };
+  }
+
+  return {
+    component,
+    themes: [theme],
   };
-
-  reactThemerJss.themer = themerInstance;
-
-  return reactThemerJss;
 };
+
+/**
+ * Check if component exists.
+ * @param  {any} component  Component to check
+ * @return {void}           Throws an error if component is falsy
+ */
+const validateComponent = (component: any) => {
+  if (!component) {
+    throw new Error('ca-ui-react-themer: a component is required');
+  }
+};
+
+/**
+ * Create `withTheme` decorator based using the provided Themer instance
+ * @param  {Object} themerInstance  Themer instance that will be used to resolve themes
+ * @return {Function}               `withTheme` decorator
+ */
+const createWithTheme = (themerInstance: Object) => (theme?: Object): WithThemeDecorator => (
+  component: any,
+) => {
+  validateComponent(component);
+  const rawThemerAttrs = getRawThemerAttrs(component, theme);
+
+  /**
+   * Resolved theme attributes are cached after first mount of this component type.
+   * We assume that all instances of this themed components will share the same theme context.
+   */
+  let resolvedAttrsCache;
+
+  /**
+   * Create decorated class component
+   */
+  class DecoratedClassComponent extends Component {
+
+    /**
+     * Wrap `displayName` of original component with Themer()
+     * @type {string}
+     */
+    static displayName = `Themer(${getDisplayName(rawThemerAttrs.component)})`;
+
+    /**
+     * Set static attribute `rawThemerAttrs` to allow themes to be extended
+     * @type {Object}
+     */
+    static rawThemerAttrs = rawThemerAttrs;
+
+    /**
+     * Define context types to get global theme object
+     * @type {Object}
+     */
+    static contextTypes = {
+      theme: PropTypes.object,
+    };
+
+    /**
+     * Resolve component themes when component mounts for the first time
+     * @return {void}
+     */
+    componentWillMount() {
+      // check if resolved theme attributes are already available
+      if (resolvedAttrsCache) {
+        return;
+      }
+
+      // Check if global theme defines any variables
+      const { theme: globalTheme } = this.context;
+      const globalVars = globalTheme && globalTheme.variables ? globalTheme.variables : undefined;
+
+      // apply variants decorator
+      const componentWithVariants = applyVariantsDecorator(rawThemerAttrs.component);
+
+      // Fetch the resolved Component and theme from the themerInstance
+      resolvedAttrsCache = themerInstance.resolveAttributes(
+        componentWithVariants, rawThemerAttrs.themes, globalVars);
+    }
+
+    /**
+     * Render themed component
+     * @return {React.Element<*>}
+     */
+    render() {
+      return React.createElement(
+        resolvedAttrsCache.snippet,
+        mapThemeProps(this.props, resolvedAttrsCache.theme),
+      );
+    }
+  }
+
+  /**
+   * Return decorated component.
+   *
+   * We disable Flow for this line because `react-flow-types` only supports
+   * Higher Order Components that return Functional components (not class components).
+   */
+  // $FlowFixMe
+  return DecoratedClassComponent;
+};
+
+/**
+ * Create `withTheme` decorator and assigns themer instance
+ * to `withTheme.themer` attribute for convenience.
+ *
+ * @param  {Themer} customThemer  custom instance of `Themer` that will be used to resolve themes
+ * @return {Function}             `withTheme` decorator with `themer` attribute
+ */
+const createDecorator = (customThemer?: ?Object) => {
+  const themerInstance = customThemer || themer;
+  const withTheme = createWithTheme(themerInstance);
+  withTheme.themer = themerInstance;
+
+  return withTheme;
+};
+
+export default createDecorator;

--- a/src/theme-provider/index.js
+++ b/src/theme-provider/index.js
@@ -15,11 +15,6 @@ type Props = {
   children?: ?React.Element<*>,
 };
 
-type DefaultProps = {
-  themer?: ?Object,
-  children?: ?React.Element<*>,
-};
-
 const OnlyChildren = ({ children }) => (
   children ?
     React.Children.only(children) :
@@ -27,10 +22,6 @@ const OnlyChildren = ({ children }) => (
 );
 
 export default class ThemeProvider extends React.Component {
-  static defaultProps: DefaultProps = {
-    themer: null,
-    children: null,
-  };
 
   static childContextTypes = {
     theme: React.PropTypes.object,

--- a/tests/theme-provider/index.spec.js
+++ b/tests/theme-provider/index.spec.js
@@ -28,6 +28,6 @@ describe('ThemeProvider', () => {
     const ProviderComponent = <ThemeProvider {...props} />;
     const renderedComponent = mount(ProviderComponent);
 
-    expect(renderedComponent.prop('children')).toBeNull();
+    expect(renderedComponent.prop('children')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Status
**READY**

## Description
* update dependencies to latest version, including `ca-ui-themer` to get changes merged from CAAPIM/themer/pull/29.
* pin `react` and `react-dom` devDependencies to `v15.4.1` because `v15.5.x` breaks the test suite.
* add flow type definitions to `react-themer` Higher Order Component using [`react-flow-types`](https://www.npmjs.com/package/react-flow-types)
* fix flow type definitions for `ThemeProvider` component

