### PR TITLE
feat: Rolled back dynamic theming commit

### DIFF
--- a/src/react-themer/index.js
+++ b/src/react-themer/index.js
@@ -14,8 +14,6 @@ import {
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import mapProps from 'recompose/mapProps';
-import isEmpty from 'lodash/isEmpty';
-import isEqual from 'lodash/isEqual';
 
 import type { ProvidedThemeProps } from 'ca-ui-themer';
 import type { HigherOrderComponent } from 'react-flow-types';
@@ -90,11 +88,6 @@ const createWithTheme = (themerInstance: Object) => (theme?: Object): WithThemeD
   let resolvedAttrsCache;
 
   /**
-   * Maintain a record of the current theme to compare future iterations against
-   */
-  let currentTheme;
-
-  /**
    * Create decorated class component
    */
   class DecoratedClassComponent extends Component {
@@ -126,7 +119,6 @@ const createWithTheme = (themerInstance: Object) => (theme?: Object): WithThemeD
     componentWillMount() {
       // Check if global theme defines any variables
       const { theme: globalTheme } = this.context;
-      currentTheme = globalTheme;
 
       // Get global theme ID
       const globalThemeId = globalTheme && globalTheme.id ? globalTheme.id : undefined;
@@ -136,39 +128,6 @@ const createWithTheme = (themerInstance: Object) => (theme?: Object): WithThemeD
       if (resolvedAttrsCache && resolvedAttrsCache.id === globalThemeId) {
         return;
       }
-
-      // Check if global theme defines any variables
-      const globalVars = globalTheme && globalTheme.variables ? globalTheme.variables : undefined;
-
-      // apply variants decorator
-      const componentWithVariants = applyVariantsDecorator(rawThemerAttrs.component);
-
-      // Fetch the resolved Component and theme from the themerInstance
-      resolvedAttrsCache = themerInstance.resolveAttributes(
-        componentWithVariants, rawThemerAttrs.themes, globalVars);
-
-      // cache global theme ID
-      resolvedAttrsCache.id = globalThemeId;
-    }
-
-    /**
-     * Resolve component themes when component updates and a new theme is present
-     * @return {void}
-     */
-    componentDidUpdate() {
-      // Check if global theme defines any variables
-      const { theme: globalTheme } = this.context;
-
-      // Get global theme ID
-      const globalThemeId = globalTheme && globalTheme.id ? globalTheme.id : undefined;
-
-      // check if currentTheme associated the the component matches the global.
-      // If not, update the currentTheme
-      if (isEmpty(currentTheme) || isEmpty(globalTheme) || isEqual(currentTheme, globalTheme)) {
-        return;
-      }
-
-      currentTheme = globalTheme;
 
       // Check if global theme defines any variables
       const globalVars = globalTheme && globalTheme.variables ? globalTheme.variables : undefined;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -97,28 +97,6 @@ describe('reactThemer', () => {
     expect(renderedThemeProp.styles.root.color).toBe(defaultGlobalVars.mainColor);
   });
 
-  it('should update currentTheme on componentDidUpdate', () => {
-    const themerReactClass = reactThemer(functionTheme)(TestComponent);
-    const renderedComponent = mount(React.createElement(themerReactClass), {
-      context: { theme: globalTheme },
-    });
-    const newTheme = {
-      variables: {
-        mainColor: 'salmon',
-      },
-    };
-    const renderedThemeProp = renderedComponent.find(TestComponent).prop('theme');
-
-    expect(renderedThemeProp.styles.root.color).toBe(globalTheme.variables.mainColor);
-
-    renderedComponent.setContext({ theme: newTheme });
-    renderedComponent.setProps({ theme: newTheme });
-
-    const reRenderedThemeProp = renderedComponent.find(TestComponent).prop('theme');
-
-    expect(reRenderedThemeProp.styles.root.color).toBe(newTheme.variables.mainColor);
-  });
-
   it('should call resolveAttributes only once', () => {
     const themer = createThemer();
 


### PR DESCRIPTION
## Status
**READY**

## Description
I'm opening this PR in case we want to use hard refreshes when the theme is updated, instead of a full dynamic theming solution. I've created a branch called `dynamic-theming` that has the dynamic theming commit in it, to work off. Until it's working I think we should remove it from master so that certain parts of the page (specifically, the Appearance Form page in the Appearance Extension) aren't updated dynamically while others require a hard refresh.

## Impacted Areas in Application
* `src/react-themer`
