### PR TITLE
feat: BREAKING CHANGE update to react 16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,22 +31,23 @@
   "dependencies": {
     "ca-ui-themer": "^2.3.0",
     "lodash": "^4.17.4",
-    "prop-types": "^15.5.10",
+    "prop-types": "^15.6.1",
     "react-flow-types": "^0.1.1",
     "recompose": ">=0.5.0"
   },
   "peerDependencies": {
-    "react": ">=0.14"
+    "react": ">=16.2.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
+    "babel-cli": "^6.26.0",
     "babel-eslint": "^7.2.3",
-    "babel-preset-ca": "^1.1.0",
+    "babel-preset-ca": "^1.1.3",
     "babel-register": "^6.24.1",
     "codecov": "2.2.0",
     "commitizen": "2.9.6",
     "cz-conventional-changelog": "2.0.0",
-    "enzyme": "^2.8.2",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^3.19.0",
     "eslint-config-ca": "^2.0.1",
     "flow-bin": "^0.48.0",
@@ -54,9 +55,8 @@
     "flow-coverage-report": "^0.3.0",
     "husky": "^0.13.4",
     "jest": "^20.0.4",
-    "react": "15.4.1",
-    "react-addons-test-utils": "15.4.1",
-    "react-dom": "15.4.1",
+    "react": "16.2.0",
+    "react-dom": "16.2.0",
     "rimraf": "^2.6.1",
     "semantic-release": "^6.3.6",
     "validate-commit-msg": "^2.12.2"

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -7,7 +7,8 @@
 // @flow
 
 import React from 'react';
-import { mount } from 'enzyme';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import { create as createThemer } from 'ca-ui-themer';
 import Themer from 'ca-ui-themer/lib/Themer';
 import reactThemer, { create as createReactThemer } from '../src';
@@ -15,6 +16,9 @@ import TestComponent from './fixtures/TestComponent';
 import theme from './fixtures/theme';
 import functionTheme from './fixtures/functionTheme';
 import globalTheme from './fixtures/globalTheme';
+
+Enzyme.configure({ adapter: new Adapter() });
+const { mount } = Enzyme;
 
 describe('reactThemer', () => {
   it('should throw if no component is passed', () => {
@@ -123,9 +127,9 @@ describe('reactThemer', () => {
     const themer = createThemer();
 
     // override resolveAttributes with spy function
-    const resolveAttributesSpy = jest.fn().mockImplementation(
-      (...args) => themer.resolveAttributes(...args),
-    );
+    const resolveAttributesSpy = jest
+      .fn()
+      .mockImplementation((...args) => themer.resolveAttributes(...args));
     const themerSpy = { resolveAttributes: resolveAttributesSpy };
 
     // create themed component

--- a/tests/theme-provider/index.spec.js
+++ b/tests/theme-provider/index.spec.js
@@ -7,10 +7,14 @@
 // @flow
 
 import React from 'react';
-import { mount } from 'enzyme';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import ThemeProvider from '../../src/theme-provider';
 import TestComponent from '../fixtures/TestComponent';
 import theme from '../fixtures/theme';
+
+Enzyme.configure({ adapter: new Adapter() });
+const { mount } = Enzyme;
 
 const props = {
   theme,
@@ -18,7 +22,11 @@ const props = {
 
 describe('ThemeProvider', () => {
   it('should contain child prop', () => {
-    const ProviderComponent = <ThemeProvider {...props}><TestComponent /></ThemeProvider>;
+    const ProviderComponent = (
+      <ThemeProvider {...props}>
+        <TestComponent />
+      </ThemeProvider>
+    );
     const renderedComponent = mount(ProviderComponent);
 
     expect(renderedComponent.prop('children')).toBeTruthy();


### PR DESCRIPTION
## Status
READY

## Description
update to react 16.2.0, this is required because PropTypes inside React is not supported, and even that this project didin't use PropTypes from the react lib, the bundle file was adding it causing problem to update the react version in the other projects that use this lib.

## Impacted Areas in Application

* package.json
